### PR TITLE
Support transparent track color

### DIFF
--- a/lib/src/swipe_button.dart
+++ b/lib/src/swipe_button.dart
@@ -135,6 +135,7 @@ class _SwipeState extends State<SwipeButton> {
         elevation: elevationTrack,
         borderRadius: borderRadius,
         clipBehavior: Clip.antiAlias,
+        color: Colors.transparent,
         child: Container(
           width: constraints.maxWidth,
           height: widget.height,


### PR DESCRIPTION
# Existing behavior
If `activeTrackColor` and/or `inactiveTrackColor` are set to `Colors.transparent` the track does not become transparent.

# New behavior
Set `activeTrackColor` and/or `inactiveTrackColor` to `Colors.transparent` to achieve a transparent track. The ability to set other colors and the fallbacks to `theme.backgroundColor` and `theme.disabledColor` are not affected.

[Fixes #2](https://github.com/lrferreiro/flutter_swipe_button/issues/2)